### PR TITLE
Replace v1.5 menu with nemesis_gui

### DIFF
--- a/v1.5/esp.cpp
+++ b/v1.5/esp.cpp
@@ -7,7 +7,7 @@
 #include "penetration.hpp"
 #include "esp.hpp"
 #include "resolver.hpp"
-#include "legacy ui/menu/menu.h"
+#include "nemesis_gui/gui_main/gui3.hpp"
 
 constexpr auto MOLOTOV_ICON = (u8"\uE02E");
 constexpr auto SMOKE_ICON = (u8"\uE02D");
@@ -145,8 +145,8 @@ void c_esp::draw_smoke_range(float& weapon_alpha, weapon_esp_t& esp, c_base_enti
 	auto& esp_config = g_cfg.visuals.esp[esp_weapon];
 	auto smoke_color = esp_config.colors.smoke_range.base();
 
-	auto smoke_timer = esp.smoke_time / 18.f;
-	g_menu.create_animation(esp.range_lerp, smoke_timer > 0.1f, 0.3f, lerp_animation);
+        auto smoke_timer = esp.smoke_time / 18.f;
+        esp.range_lerp = smoke_timer > 0.1f ? 1.f : 0.f;
 
 	auto base_origin = entity->get_abs_origin();
 	auto world_position = get_world_position(base_origin, 160.5f * esp.range_lerp);
@@ -211,8 +211,8 @@ void c_esp::draw_molotov_range(float& weapon_alpha, weapon_esp_t& esp, c_base_en
 
 	constexpr auto fire_time = 7.03125f;
 
-	auto fire_timer = esp.inferno_time / fire_time;
-	g_menu.create_animation(esp.range_lerp, fire_timer > 0.1f, 0.3f, lerp_animation);
+        auto fire_timer = esp.inferno_time / fire_time;
+        esp.range_lerp = fire_timer > 0.1f ? 1.f : 0.f;
 
 	vec2_t origin{};
 	if (!RENDER->world_to_screen(base_origin, origin))

--- a/v1.5/eventlistener.cpp
+++ b/v1.5/eventlistener.cpp
@@ -14,7 +14,6 @@ void c_event_listener::fire_game_event(c_game_event* event)
 
 	if (!std::strcmp(event->get_name(), CXOR("round_start")))
 	{
-        g_menu.reset_game_info();
         MOVEMENT->reset();
         BULLET_TRACERS->reset();
         ESP->reset();

--- a/v1.5/features.hpp
+++ b/v1.5/features.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 // FEATURES
-#include "legacy ui/menu/menu.h" 
+#include "nemesis_gui/gui_main/gui3.hpp"
 
 #include "esp_object_render.hpp"
 #include "entlistener.hpp"

--- a/v1.5/globals.cpp
+++ b/v1.5/globals.cpp
@@ -110,8 +110,7 @@ void c_hacks::init(LPVOID reserved)
 	RENDER->update_screen();
 
 	DEBUG_LOG(" [+] Reset GUI & Binds \n");
-	g_menu.reset_init();
-	g_cfg.reset_init();
+        g_cfg.reset_init();
 
 	DEBUG_LOG(" [+] Chams materials \n");
 	CHAMS->init_materials();

--- a/v1.5/grenade_prediction.cpp
+++ b/v1.5/grenade_prediction.cpp
@@ -1,7 +1,7 @@
 #include "globals.hpp"
 #include "grenade_prediction.hpp"
 #include "entlistener.hpp"
-#include "legacy ui/menu/menu.h"
+#include "nemesis_gui/gui_main/gui3.hpp"
 
 void nade_path_t::perform_fly_collision_resolution(c_game_trace& trace)
 {
@@ -387,8 +387,8 @@ void c_grenade_prediction::draw_world_path()
 		if (data.nade_detonate_time)
 			grenade_duration = std::clamp(std::abs(data.nade_expire_time - HACKS->global_vars->curtime) / data.nade_detonate_time, 0.f, 1.f);
 
-		g_menu.create_animation(mod, data.path.size() > 1 && data.is_detonated, 0.3f, lerp_animation);
-		g_menu.create_animation(oof_nade_alpha[l.first], l.second.offscreen && mod > 0.f, 0.3f, lerp_animation);
+                mod = data.path.size() > 1 && data.is_detonated ? 1.f : 0.f;
+                oof_nade_alpha[l.first] = (l.second.offscreen && mod > 0.f) ? 1.f : 0.f;
 
 		if (mod <= 0.f)
 			continue;

--- a/v1.5/vmt_hooks.cpp
+++ b/v1.5/vmt_hooks.cpp
@@ -158,10 +158,7 @@ namespace hooks::vmt
 
 			if (RENDER->done)
 			{
-				// LEGACY CODE FROM OLD SOURCE
-				g_menu.store_bomb();
-				g_menu.store_spectators();
-				// LEGACY END
+                                // menu indicators are handled by nemesis_gui
 
 				RENDER->list_start();
 				{
@@ -247,8 +244,7 @@ namespace hooks::vmt
 		//  THREAD_POOL->wait_all();
 		//  THREAD_POOL->wait_all();
 
-		HACKS->reset_ctx_values();
-		g_menu.reset_game_info();
+                HACKS->reset_ctx_values();
 		MOVEMENT->reset();
 		BULLET_TRACERS->reset();
 		// EVENT_LOGS->reset();
@@ -284,8 +280,7 @@ namespace hooks::vmt
 
 		//  THREAD_POOL->wait_all();
 
-		HACKS->reset_ctx_values();
-		g_menu.reset_game_info();
+                HACKS->reset_ctx_values();
 		MOVEMENT->reset();
 		BULLET_TRACERS->reset();
 		//   EVENT_LOGS->reset();
@@ -410,9 +405,9 @@ namespace hooks::vmt
 		}
 
 		imgui_blur::set_device(device);
-		imgui_blur::new_frame();
+                imgui_blur::new_frame();
 
-		g_menu.draw();
+                ui::m_details.install();
 
 		if (g_cfg.legit.enable)
 		{


### PR DESCRIPTION
## Summary
- switch `features.hpp`, `esp.cpp`, and `grenade_prediction.cpp` to include the new nemesis GUI
- drop legacy menu calls in various modules
- hook nemesis GUI rendering into `vmt_hooks`
- simplify some animation code

## Testing
- `echo "no tests"`